### PR TITLE
Add quotes to 'type' property in Notify example on the website

### DIFF
--- a/website/assets/js/main.js
+++ b/website/assets/js/main.js
@@ -133,7 +133,7 @@ btn.addEventListener('click', () => {
     autotimeout: ${notify_object.autotimeout},
     notificationsGap: ${notify_object.notificationsGap},
     notificationsPadding: ${notify_object.notificationsPadding},
-    type: ${notify_object.type},
+    type: '${notify_object.type}',
     position: '${notify_object.position}',
     customWrapper: '${notify_object.customWrapper}',
   })


### PR DESCRIPTION
Added single quotes around the 'type' property in the Notify example on the project website. Previously, the example code would show `type: outline`/`type: filled` without the quotes, which suggests that `outline`/`filled` is a variable or constant, not a string. It now properly shows `type: 'outline'`/`type: 'filled'`