### PR TITLE
Fix close icon overlap

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -268,6 +268,10 @@
   animation: progress var(--sn-notify-autoclose-timeout) linear forwards;
 }
 
+.sn-notify-content {
+  padding-right: calc(var(--sn-notify-close-icon-size) + 2px);
+}
+
 @keyframes progress {
   to {
     width: 0%;


### PR DESCRIPTION
Before the fix

![image](https://github.com/user-attachments/assets/6b8e0b44-0ac2-4974-94df-9c780632dd90)

And after

![image](https://github.com/user-attachments/assets/26c65eaa-633b-4c36-9254-2284d3cb32cc)
