### PR TITLE
Add type export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import './style.css'
 import type { IArgs, NotifyEffect, NotifyPosition, NotifyStatus, NotifyType } from './types'
 import { stringToHTML } from './utils'
 
+export type { IArgs, NotifyEffect, NotifyPosition, NotifyStatus, NotifyType }
+
 export default class Notify {
   wrapper: HTMLElement
   customWrapper: string


### PR DESCRIPTION
Exports types (`IArgs, NotifyEffect, NotifyPosition, NotifyStatus, NotifyType`) to make them available for users.

Resolve issue https://github.com/simple-notify/simple-notify/issues/51